### PR TITLE
Global minify source

### DIFF
--- a/_dev/gulp/tasks/css/minify.js
+++ b/_dev/gulp/tasks/css/minify.js
@@ -17,7 +17,7 @@ module.exports = function (gulp, plugins, settings, handlers) {
       console.log('css:minify:global task...');
     }
 
-    return gulp.src(settings.files.dev.css)
+    return gulp.src(settings.files.public.css)
       .pipe(plugins.plumber({errorHandler: handlers.error}))
       .pipe(plugins.postcss([
         autoprefixer,


### PR DESCRIPTION
Global minify task source changed due to SVGs not being converted into base64.